### PR TITLE
Add Error Handling Tests for PATCH /api/articles Endpoint

### DIFF
--- a/__tests__/db.test.js
+++ b/__tests__/db.test.js
@@ -282,6 +282,39 @@ describe("PATCH /api/articles/:article_id", () => {
         expect(msg).toBe("ERROR! Missing required data");
       });
   });
+  test(`PATCH 400: responds with an error when patch request property is of invalid type`, () => {
+    const updatedArticle = { inc_votes: "invalid" };
+    return request(app)
+      .patch("/api/articles/5")
+      .send(updatedArticle)
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Bad request");
+      });
+  });
+  test(`PATCH 400: responds with an error when invalid ID is passed`, () => {
+    const updatedArticle = { inc_votes: 20 };
+    return request(app)
+      .patch("/api/articles/cars")
+      .send(updatedArticle)
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("Bad request");
+      });
+  });
+  test(`PATCH 404: responds with an error when valid ID is passed, but does not exist in database`, () => {
+    const updatedArticle = { inc_votes: 20 };
+    return request(app)
+      .patch("/api/articles/500")
+      .send(updatedArticle)
+      .expect(404)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe("ID does not exist");
+      });
+  });
   test("PATCH 404: responds with an error when wrong endpoint inserted", () => {
     const updatedArticle = { inc_votes: 20 };
     return request(app)

--- a/db/models/articles-model.js
+++ b/db/models/articles-model.js
@@ -82,12 +82,16 @@ exports.changeArticleById = (article_id, inc_votes) => {
       msg: "ERROR! Missing required data",
     });
   }
+
   return db
     .query(
       `UPDATE articles SET votes = votes + $1 WHERE article_id = $2 RETURNING *;`,
       [inc_votes, article_id]
     )
     .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({ status: 404, msg: "ID does not exist" });
+      }
       return rows[0];
     });
 };


### PR DESCRIPTION
- Added tests for error handling in PATCH /api/articles when provided with:
  - Invalid property type (400 response).
  - Invalid ID type (400 response).
  - Valid but non-existent ID (404 response).
