### PR TITLE
Add test case for GET /api/articles to handle valid topic with no associated articles

### DIFF
--- a/__tests__/db.test.js
+++ b/__tests__/db.test.js
@@ -194,6 +194,15 @@ describe("GET /api/articles", () => {
         });
       });
   });
+  test("GET 200: Responds with an empty array when there are no associated articles with the topic", () => {
+    return request(app)
+      .get("/api/articles?topic=paper")
+      .expect(200)
+      .then(({ body }) => {
+        const { articles } = body;
+        expect(articles).toHaveLength(0);
+      });
+  });
   test(`GET 404: responds with error when topic inserted doesn't exist`, () => {
     return request(app)
       .get(`/api/articles?topic=planets`)

--- a/db/controllers/articles-controller.js
+++ b/db/controllers/articles-controller.js
@@ -7,6 +7,7 @@ const {
   insertComment,
   changeArticleById,
   removeCommentById,
+  checkTopicExists,
 } = require("../models/articles-model");
 
 exports.getSingleArticle = (request, response, next) => {
@@ -22,8 +23,13 @@ exports.getSingleArticle = (request, response, next) => {
 
 exports.getArticles = (request, response, next) => {
   const { topic } = request.query;
-  fetchArticles(topic)
-    .then((articles) => {
+
+  const articlePromise = fetchArticles(topic);
+
+  const topicPromise = topic ? checkTopicExists(topic) : Promise.resolve();
+
+  Promise.all([articlePromise, topicPromise])
+    .then(([articles]) => {
       response.status(200).send({ articles });
     })
     .catch((err) => {

--- a/db/models/articles-model.js
+++ b/db/models/articles-model.js
@@ -27,9 +27,6 @@ exports.fetchArticles = (topic) => {
   queryStr += ` ORDER BY created_at desc`;
 
   return db.query(queryStr, queryVal).then(({ rows }) => {
-    if (rows.length === 0) {
-      return Promise.reject({ status: 404, msg: "ERROR! Topic not found!" });
-    }
     return rows;
   });
 };
@@ -51,6 +48,16 @@ exports.checkArticleExists = (article_id) => {
     .then(({ rows }) => {
       if (rows.length === 0) {
         return Promise.reject({ status: 404, msg: "error! ID not found" });
+      }
+    });
+};
+
+exports.checkTopicExists = (topic) => {
+  return db
+    .query(`SELECT * FROM topics WHERE slug = $1`, [topic])
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({ status: 404, msg: "ERROR! Topic not found!" });
       }
     });
 };


### PR DESCRIPTION
I added a new test case to the GET /API/articles endpoint to ensure that the API correctly responds with a 200 status code and an empty array when a valid topic exists but has no associated articles.