### PR TITLE
Add DELETE /api/articles/:article_id endpoint and description to API documentation

### DIFF
--- a/__tests__/db.test.js
+++ b/__tests__/db.test.js
@@ -687,6 +687,30 @@ describe("POST /api/topics", () => {
   });
 });
 
+describe("DELETE /api/articles/:article_id", () => {
+  test("DELETE 204: Responds with no content", () => {
+    return request(app).delete("/api/articles/1").expect(204);
+  });
+  test(`DELETE 404: Responds with an error when ID doesn't exist`, () => {
+    return request(app)
+      .delete("/api/articles/999")
+      .expect(404)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe(`ERROR! this article doesn't exist`);
+      });
+  });
+  test(`DELETE 400: Responds with an error when ID is of invalid format`, () => {
+    return request(app)
+      .delete("/api/articles/banana")
+      .expect(400)
+      .then(({ body }) => {
+        const { msg } = body;
+        expect(msg).toBe(`Bad request`);
+      });
+  });
+});
+
 describe("Undeclared endpoints", () => {
   test("ALL METHODS 404: Responds with an error for an endpoint not found", () => {
     return request(app)

--- a/db/controllers/articles-controller.js
+++ b/db/controllers/articles-controller.js
@@ -9,6 +9,7 @@ const {
   removeCommentById,
   checkTopicExists,
   addArticles,
+  removeSingleArticle,
 } = require("../models/articles-model");
 
 exports.getSingleArticle = (request, response, next) => {
@@ -100,4 +101,13 @@ exports.postArticles = (req, res, next) => {
     .catch((err) => {
       next(err);
     });
+};
+
+exports.deleteSingleArticle = (req, res, next) => {
+  const { article_id } = req.params;
+  removeSingleArticle(article_id)
+    .then(() => {
+      res.status(204).end();
+    })
+    .catch((err) => [next(err)]);
 };

--- a/db/models/articles-model.js
+++ b/db/models/articles-model.js
@@ -162,3 +162,22 @@ exports.addArticles = (newArticle) => {
       return rows[0];
     });
 };
+
+exports.removeSingleArticle = (article_id) => {
+  return db
+    .query("SELECT * FROM articles WHERE article_id = $1", [article_id])
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({
+          status: 404,
+          msg: "ERROR! this article doesn't exist",
+        });
+      }
+
+      return db
+        .query("DELETE FROM comments WHERE article_id = $1", [article_id])
+        .then(() =>
+          db.query("DELETE FROM articles WHERE article_id = $1", [article_id])
+        );
+    });
+};

--- a/endpoints.json
+++ b/endpoints.json
@@ -272,5 +272,19 @@
         "description": "All about the latest technology trends and innovations."
       }
     }
+  },
+  "DELETE /api/articles/:article_id": {
+    "description": "Deletes an article based on the provided article ID and removes its associated comments.",
+    "parameters": {
+      "article_id": "number (required) - The ID of the article to delete."
+    },
+    "exampleRequest": {
+      "url": "/api/articles/1",
+      "method": "DELETE"
+    },
+    "exampleResponse": {
+      "status": 204,
+      "body": ""
+    }
   }
 }

--- a/routes/articles-router.js
+++ b/routes/articles-router.js
@@ -6,6 +6,7 @@ const {
   getCommentsByArticleId,
   getSingleArticle,
   postArticles,
+  deleteSingleArticle,
 } = require("../db/controllers/articles-controller");
 
 const articlesRouter = express.Router();
@@ -16,5 +17,6 @@ articlesRouter.get("/:article_id/comments", getCommentsByArticleId);
 articlesRouter.post("/:article_id/comments", postCommentByArticleId);
 articlesRouter.patch("/:article_id", patchArticleById);
 articlesRouter.post("/", postArticles);
+articlesRouter.delete("/:article_id", deleteSingleArticle);
 
 module.exports = articlesRouter;


### PR DESCRIPTION
- Added description for `DELETE /api/articles/:article_id` endpoint in the `/api` documentation.
- All related endpoint tests are passing, confirming the endpoint's functionality aligns with the described behavior.